### PR TITLE
Document layered architecture and dependency rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ libcoda
 
 a c++17 utility library.  Its my toolkit for anything c++17.
 
+Architecture
+============
+
+Modernization follows explicit layered-dependency, error-handling, and dependency-management rules:
+
+- [System context](docs/architecture/0001-system-context.md)
+- [Layered architecture and SOLID guidance](docs/architecture/0002-layered-architecture.md)
+- [Error handling policy](docs/architecture/0003-error-handling.md)
+- [Dependency policy](docs/architecture/0004-dependency-policy.md)
+- [ADR 0001: retain component repositories and submodules during modernization](docs/adr/0001-submodules-vs-monorepo.md)
+
+The architecture documents describe target constraints for modernization; they do not imply every legacy component already conforms.
+
 Submodules
 ==========
 

--- a/docs/adr/0001-submodules-vs-monorepo.md
+++ b/docs/adr/0001-submodules-vs-monorepo.md
@@ -1,0 +1,127 @@
+# ADR 0001 — Retain component repositories and submodules during modernization
+
+## Status
+
+Accepted for the current modernization phase.
+
+## Context
+
+`libcoda` currently integrates independently versioned component repositories through Git submodules. The arrangement adds operational complexity, but it also represents real component/release boundaries: format, database, networking, and other libraries can evolve and validate independently before the aggregate repository advances its gitlink.
+
+A monorepo could simplify atomic changes and shared tooling, but migrating source control structure before component contracts are stabilized would mix architectural refactoring with repository migration and make regressions harder to attribute.
+
+## Decision question
+
+Should libcoda preserve the current multi-repository/submodule topology during modernization, or migrate immediately to a monorepo/workspace?
+
+## Alternatives
+
+### A. Retain the current repositories and submodules
+
+Component repositories remain independent. The aggregate repository pins exact component commits and validates them recursively.
+
+Advantages:
+
+- preserves existing release/history boundaries;
+- keeps component modernization slices small and attributable;
+- allows component CI/fuzzing to mature independently;
+- makes aggregate gitlink advancement an explicit integration gate;
+- avoids a large source-control migration while architecture is still changing.
+
+Costs:
+
+- cross-repository changes require ordered PRs/commits;
+- stale gitlinks can hide component progress;
+- tooling/CI conventions can drift;
+- local checkout and contributor workflow are more complex.
+
+### B. Immediate monorepo migration
+
+Move component history/source into a single repository and replace submodule integration with normal subdirectories/workspaces.
+
+Advantages:
+
+- atomic cross-component changes;
+- simpler checkout and code search;
+- one CI/security/tooling policy surface;
+- easier repository-wide refactors.
+
+Costs:
+
+- migration itself is high-churn and hard to separate from behavioral modernization;
+- release/version boundaries must be redesigned at the same time;
+- existing component repository consumers/history may be disrupted;
+- broad commits can obscure which component introduced a regression.
+
+### C. Package-only composition
+
+Keep component repositories independent but remove submodules; consume released/installable component packages from the aggregate repository.
+
+Advantages:
+
+- stronger release boundaries;
+- aggregate repository becomes a true consumer rather than a source checkout orchestrator;
+- reduced nested Git complexity.
+
+Costs:
+
+- requires mature package/export/versioning contracts that do not yet exist consistently;
+- slows coordinated development until component release automation is reliable;
+- makes testing unpublished coordinated changes more complex.
+
+## Recommendation
+
+Choose **A: retain component repositories and Git submodules during the current modernization phase**.
+
+This is a sequencing decision, not a claim that submodules are the ideal permanent topology.
+
+The immediate architectural work is to make component contracts, CMake targets, tests, security boundaries, and packaging explicit. Once those boundaries are stable, the project can reassess whether submodules still provide value or merely impose coordination cost.
+
+## Decision
+
+For the current phase:
+
+1. Component repositories remain independently maintained.
+2. `libcoda` pins exact component SHAs as Git submodules.
+3. Component changes should be validated in their own repository when practical.
+4. Aggregate gitlink changes require recursive integration CI before merge.
+5. Cross-repository modernization should be split into bounded component PRs followed by a small aggregate integration change.
+6. No new third-party dependency should use Git submodules merely because project components do.
+7. Monorepo migration is deferred until packaging/API/test boundaries are sufficiently stable to evaluate it on operational merits rather than as a modernization shortcut.
+
+## Tradeoffs accepted
+
+We accept additional coordination and gitlink maintenance in exchange for lower migration risk and clearer fault isolation during modernization.
+
+The aggregate CI/build system must compensate for the topology by detecting:
+
+- stale or invalid component SHAs;
+- dependency-policy incompatibilities;
+- component CMake/test option drift;
+- integration failures caused by independently evolving component heads.
+
+## Revisit criteria
+
+Reopen this ADR when at least most of the following are true:
+
+- component public targets/install/export behavior are stable;
+- test/fuzz/static-analysis conventions are consistent;
+- component release/version policy is documented;
+- aggregate CI is reliable and cross-repository change frequency is measurable;
+- the ongoing coordination cost of submodules is known rather than assumed.
+
+At that point compare submodules, monorepo, and package-only composition using concrete metrics: change coupling, release cadence, CI time, contributor friction, and rollback/release independence.
+
+## Consequences
+
+Positive:
+
+- modernization can proceed incrementally with explicit integration evidence;
+- component CI and architecture can improve without waiting for repository migration;
+- accidental cross-component coupling remains visible.
+
+Negative:
+
+- multi-repo coordination remains part of the SDLC;
+- aggregate gitlinks must be deliberately maintained;
+- architecture/tooling documentation must distinguish component and aggregate responsibilities.

--- a/docs/architecture/0001-system-context.md
+++ b/docs/architecture/0001-system-context.md
@@ -1,0 +1,77 @@
+# 0001 — System context
+
+## Status
+
+Accepted as modernization guidance.
+
+## Purpose
+
+`libcoda` is an aggregate C++17 toolkit and integration repository. It assembles a set of utility libraries, including database, networking, formatting, logging, math, string, terminal, threading, and general utility components.
+
+The aggregate repository has two responsibilities:
+
+1. provide a reproducible integration/build surface for the component libraries;
+2. define project-wide architecture, dependency, testing, and security policy that component repositories can adopt incrementally.
+
+It is not intended to become a framework that forces unrelated utility domains behind one abstraction hierarchy.
+
+## Current topology
+
+The codebase is a hybrid multi-repository system:
+
+- `libcoda` owns the aggregate build, integration CI, in-tree utility components, and project-wide policy;
+- `libcoda-format`, `libcoda-db`, `libcoda-net`, and other independently versioned components are consumed through Git submodules;
+- the shared `cmake` repository provides legacy CMake helpers used by several components;
+- some component CMake and test conventions remain independent and are being converged incrementally.
+
+The submodule boundary is therefore both a source-control boundary and a release/integration boundary. A change to a component is not part of an aggregate release until the aggregate gitlink is advanced and the recursive integration build passes.
+
+## Intended consumers
+
+The primary consumers are:
+
+- C++ applications that use one or more libcoda component libraries;
+- the aggregate libcoda build used to validate compatibility across components;
+- maintainers extending or modernizing individual components;
+- CI/fuzz/security tooling that needs deterministic component boundaries.
+
+## Architectural drivers
+
+Modernization prioritizes:
+
+1. **correctness and explicit contracts** — parsing, state, ownership, error, and lifecycle behavior should be testable and documented;
+2. **dependency direction** — domain and parsing logic should not depend on concrete database, socket, TLS, or platform adapters;
+3. **deterministic builds** — normal builds should not require network dependency downloads or external services;
+4. **security** — untrusted format strings, URIs, network data, SQL inputs, and credentials cross explicit trust boundaries;
+5. **testability** — pure logic should be testable without sockets or database services, with SQLite/fakes used for deterministic integration where appropriate;
+6. **incremental compatibility** — modernization should avoid unnecessary public API or ABI breakage and should isolate deliberate compatibility changes.
+
+## Maturity
+
+The aggregate build and several components are in active modernization. The architecture in this document describes the intended dependency rules; it does not imply every existing component already conforms.
+
+Known transitional areas include:
+
+- legacy global compiler settings and CMake helper behavior;
+- component-specific test setup;
+- service-coupled DB/network tests;
+- concrete adapter details leaking into higher-level code;
+- public-header and package-layout inconsistencies;
+- legacy dependencies retained for compatibility.
+
+These should be treated as migration debt, not precedent for new code.
+
+## Non-goals
+
+The modernization effort does not require:
+
+- converting every component into a single monolithic library;
+- introducing interfaces where there is only one stable implementation and no testability benefit;
+- hiding standard-library value types behind project-specific wrappers;
+- replacing working algorithms solely to use newer language syntax;
+- moving all repositories into a monorepo before component boundaries are understood;
+- preserving accidental behavior caused by undefined, unsafe, or undocumented implementation details.
+
+## Change rule
+
+When a modernization change crosses a public API, component boundary, dependency direction, ownership/lifetime contract, or security boundary, the change should be justified by tests and, when durable, captured in architecture documentation or an ADR.

--- a/docs/architecture/0002-layered-architecture.md
+++ b/docs/architecture/0002-layered-architecture.md
@@ -1,0 +1,158 @@
+# 0002 — Layered architecture
+
+## Status
+
+Accepted as modernization guidance.
+
+## Mental model
+
+Each libcoda component should be understandable as a small dependency graph rather than a stack of inheritance layers. Dependencies point inward toward stable policy and value semantics; external systems remain at the edge.
+
+```mermaid
+flowchart TB
+    Consumer[Consumer application]
+    API[Public API / facade]
+    Domain[Domain models and pure logic]
+    Ports[Ports / narrow capability interfaces]
+    Adapters[Adapters]
+    External[DBs / sockets / TLS / OS / third-party libraries]
+
+    Consumer --> API
+    API --> Domain
+    API --> Ports
+    Adapters --> Ports
+    Adapters --> Domain
+    Adapters --> External
+
+    classDef forbidden stroke-dasharray: 5 5;
+```
+
+The important rule is not the number of boxes. It is that domain/parser/query logic does not acquire a dependency on concrete infrastructure merely because that infrastructure is convenient to call.
+
+## Layer responsibilities
+
+### Public API / facade
+
+Owns the supported consumer-facing types and entry points.
+
+It should:
+
+- expose stable value-oriented contracts where practical;
+- avoid namespace pollution and implementation-only dependencies;
+- make ownership and error behavior clear;
+- delegate concrete infrastructure work rather than embedding platform/service logic in public headers.
+
+### Domain models and pure logic
+
+Owns deterministic transformations and invariants.
+
+Examples include:
+
+- format grammar/specifier models and rendering rules;
+- SQL values, query models, clauses, bind mapping, and SQL generation;
+- URI and protocol parsing/encoding;
+- state/lifecycle validation that does not require a live external resource.
+
+This layer should have the highest unit-test and fuzz-test density because it can run without external services.
+
+### Ports / capability interfaces
+
+Ports exist where they provide a real seam for substitution, lifecycle isolation, or testing.
+
+Good candidates include:
+
+- DB session/statement/transaction capabilities;
+- network transport read/write/close behavior;
+- TLS wrapping/verification capability;
+- time/filesystem/platform operations only when a component actually needs them.
+
+Ports should be narrow. Avoid a single broad `database` or `network` interface that forces unrelated capabilities together.
+
+### Adapters
+
+Adapters translate a port/domain contract to a concrete dependency.
+
+Examples:
+
+- SQLite, MySQL, and PostgreSQL session/statement/result adapters;
+- POSIX/Windows socket adapters;
+- OpenSSL secure-layer adapters;
+- libcurl HTTP client adapters;
+- uriparser/cereal integration.
+
+Adapter-specific types, headers, error codes, and lifecycle quirks should not leak inward unless the public contract deliberately exposes them.
+
+## Component-specific target shape
+
+### Format
+
+Target direction:
+
+```text
+format public API
+  -> format parser/specifier model
+  -> renderer / argument state
+```
+
+Parsing should not require rendering side effects. Fuzz targets should be able to exercise parser/state transitions deterministically.
+
+### Database
+
+Target direction:
+
+```text
+query/value/model
+  -> SQL generation + bind semantics
+  -> DB capability contracts
+  <- SQLite/MySQL/PostgreSQL adapters
+```
+
+Query construction and SQL generation must not depend on a live DB connection. Backend-specific OIDs, handles, headers, and error codes belong in backend adapters.
+
+### Networking
+
+Target direction:
+
+```text
+URI/protocol models + parsers
+  -> transport capability
+  <- socket adapter
+  <- TLS adapter/wrapper
+  -> sync/async orchestration
+  -> HTTP/telnet behavior
+```
+
+Protocol parsing should be separable from socket I/O. TLS verification policy should be explicit rather than an incidental socket option.
+
+## Dependency rules
+
+New or materially changed code should satisfy these rules:
+
+1. Public/domain code must not include concrete DB, socket, TLS, or OS implementation headers unless that dependency is explicitly part of the public contract.
+2. Pure parsers, encoders, query builders, and value conversions must be runnable without live external services.
+3. Adapter targets may depend on third-party/platform APIs; core targets should not gain those dependencies merely to reuse adapter helpers.
+4. Optional backends should be represented by optional targets, not by dangling target names or global preprocessor state.
+5. Build options and compile definitions should be target-owned where possible.
+6. Cross-component dependencies must be explicit in CMake target linkage and public include interfaces.
+7. A test seam is not automatically a production abstraction: introduce a port when substitution represents a meaningful capability boundary.
+
+## SOLID applied pragmatically
+
+- **Single Responsibility:** separate parsing, rendering, query modeling, backend adaptation, transport, TLS, and orchestration when they change for different reasons.
+- **Open/Closed:** add concrete DB/network adapters through bounded targets/capabilities instead of scattering backend conditionals through core logic.
+- **Liskov:** interchangeable adapters must obey the same documented success, error, ownership, and lifecycle contracts.
+- **Interface Segregation:** model capabilities such as transaction, statement execution, transport read/write, and TLS wrapping independently when callers need different subsets.
+- **Dependency Inversion:** policy/domain code depends on stable capability contracts; infrastructure implements them.
+
+SOLID is a constraint on coupling, not a mandate for deep class hierarchies.
+
+## Review checklist
+
+For a change crossing layers, reviewers should ask:
+
+- Can the core behavior be tested without the external system?
+- Did a concrete dependency move inward unnecessarily?
+- Is ownership/lifetime still obvious?
+- Is this abstraction justified by a capability boundary or only by anticipated reuse?
+- Does the CMake target graph match the source dependency graph?
+- Could untrusted input reach an adapter before validation/normalization that belongs in a pure layer?

--- a/docs/architecture/0002-layered-architecture.md
+++ b/docs/architecture/0002-layered-architecture.md
@@ -23,9 +23,9 @@ flowchart TB
     Adapters --> Ports
     Adapters --> Domain
     Adapters --> External
-
-    classDef forbidden stroke-dasharray: 5 5;
 ```
+
+The arrows describe source/compile-time dependency direction, not runtime control flow. Adapter selection and wiring happens at the composition/factory edge appropriate to the component or consuming application.
 
 The important rule is not the number of boxes. It is that domain/parser/query logic does not acquire a dependency on concrete infrastructure merely because that infrastructure is convenient to call.
 

--- a/docs/architecture/0003-error-handling.md
+++ b/docs/architecture/0003-error-handling.md
@@ -1,0 +1,117 @@
+# 0003 — Error handling policy
+
+## Status
+
+Accepted as modernization guidance.
+
+## Principles
+
+Errors are part of a component contract. A caller should be able to distinguish malformed external input, invalid API/state usage, and infrastructure failure without depending on undefined behavior or backend-specific implementation details.
+
+## Required rules
+
+1. Throw exception objects by value; never `throw new ...` or otherwise transfer exception ownership through raw pointers.
+2. Do not use null dereference, assertion failure, process termination, or undefined behavior as normal invalid-input handling.
+3. Preserve useful causal information when translating backend errors, but do not expose secrets merely to make an error descriptive.
+4. Prefer a small, documented exception surface over creating a unique exception class for every branch.
+5. Destructors and cleanup paths must not throw during ordinary resource release.
+6. A moved-from or closed object may have restricted operations, but those restrictions must be deterministic and documented rather than relying on stale internal pointers/handles.
+
+## Error categories
+
+### Parse / validation errors
+
+Examples:
+
+- malformed format specifier;
+- invalid URI;
+- unsupported or malformed protocol field;
+- invalid SQL/query-builder input that can be detected before execution.
+
+These are recoverable caller/input errors. Components should reject them deterministically at the pure parsing/model boundary when possible.
+
+Use `std::invalid_argument` while the existing public API relies on standard exceptions, or a component-specific parse/validation exception when the component already has a stable hierarchy. Do not expose `std::stoi`/third-party parser exceptions accidentally as the public contract.
+
+### Invalid state / programmer errors
+
+Examples:
+
+- binding more arguments than a format has specifiers;
+- executing through a session/statement that has no valid underlying resource;
+- committing an already completed transaction;
+- using a transport after ownership has been transferred or closure is final.
+
+If the invalid state is possible through a public runtime sequence, detect it and return/throw a documented failure rather than asserting. Assertions remain appropriate for internal invariants that cannot be caused by supported public input or lifecycle calls.
+
+### Infrastructure / adapter failures
+
+Examples:
+
+- database connection/query failure;
+- DNS/socket/TLS failure;
+- filesystem/platform failure;
+- third-party library failure.
+
+Adapters should translate implementation-specific errors at the adapter boundary when callers do not need the raw type. Preserve backend diagnostic text/code where useful, but attach it to a stable component-level error model.
+
+A DB/network abstraction should not require callers to include MySQL/PostgreSQL/OpenSSL/platform headers merely to catch normal operational failures.
+
+## Exception hierarchy direction
+
+Do not introduce a project-wide inheritance tree preemptively. Prefer component-scoped hierarchies where they add observable value.
+
+A reasonable target is:
+
+```text
+std::exception
+  -> coda::<component>::exception
+       -> parse/validation error       (only if standard invalid_argument is insufficient)
+       -> state/lifecycle error
+       -> adapter/operation error
+```
+
+Backend-specific detail should normally be data carried by an adapter/operation error, not another public inheritance level.
+
+## Recoverable versus fatal
+
+Library code should treat most input, lifecycle, and infrastructure failures as recoverable by the embedding application.
+
+Fatal process behavior is appropriate only when:
+
+- continuing would violate memory/process safety and no safe error path exists; or
+- the embedding application explicitly chooses to terminate after receiving a library error.
+
+A reusable library should not call `exit`, `abort`, or terminate the process for an ordinary parse, DB, network, or configuration failure.
+
+## Ownership and cleanup
+
+Resource-owning types should make ownership obvious through RAII and move/copy policy.
+
+- Prefer value members, smart pointers, or narrowly owned native handles over ambiguous raw owning pointers.
+- Closing/releasing a resource should be idempotent where practical.
+- Partial construction or adapter failure must not leak sockets, DB handles, buffers, or TLS state.
+- Exception paths should provide at least the basic exception guarantee; stronger guarantees should be used for value/model operations where practical.
+
+## Security and diagnostics
+
+Error text and logs must not expose:
+
+- DB URI passwords or credentials;
+- TLS/private-key material;
+- authentication headers/tokens;
+- unbounded attacker-controlled payloads.
+
+When an input is useful for diagnosis, log a bounded/redacted representation or metadata rather than the raw secret-bearing value.
+
+## Testing expectations
+
+For each public error contract that is modernized, add tests for:
+
+- the successful path;
+- malformed input;
+- invalid lifecycle/state transitions;
+- adapter failure translation where practical;
+- cleanup after failure;
+- redaction when errors/logging can contain credentials or sensitive input.
+
+Fuzz harnesses should classify documented parse/validation exceptions as expected outcomes and allow crashes, sanitizer failures, invariant violations, or unexpected exception types to surface as findings.

--- a/docs/architecture/0004-dependency-policy.md
+++ b/docs/architecture/0004-dependency-policy.md
@@ -1,0 +1,115 @@
+# 0004 — Dependency policy
+
+## Status
+
+Accepted as modernization guidance.
+
+## Goals
+
+Dependency management should make libcoda builds reproducible, reviewable, and usable offline after required dependencies are provisioned. Optional component features should not silently turn a normal compile into a network operation.
+
+## Dependency order of preference
+
+For normal library builds, prefer dependencies in this order:
+
+1. **CMake imported/config targets supplied by the build environment** — for example `Threads::Threads`, `cereal::cereal`, OpenSSL targets, or package-provided targets where available.
+2. **System/package-manager dependencies discovered by CMake** — appropriate for common native dependencies such as SQLite, PostgreSQL/libpq, MySQL/MariaDB client libraries, curl, json-c, and uriparser.
+3. **Explicitly pinned fetched/vendored dependencies** — allowed only when the user intentionally enables that mode or when a hermetic packaging workflow owns the fetch outside the normal build.
+
+A normal `cmake --preset dev` or `release` path should not require arbitrary network access to GitHub or another package source.
+
+## Build-time network policy
+
+### Default
+
+Build-time dependency downloads are **off by default** for migrated code.
+
+If a component retains an `ExternalProject`, `FetchContent`, package-manager bootstrap, or equivalent compatibility path, it must:
+
+- be behind an explicit option such as `CODA_FETCH_DEPS=ON`;
+- pin an immutable tag/commit/version;
+- document what is downloaded and why;
+- avoid changing the dependency graph when the option is off;
+- remain non-required for aggregate CI unless the CI job exists specifically to test the fallback.
+
+### Rationale
+
+Implicit downloads create several risks:
+
+- upstream compromise or tag drift enters the build trust boundary;
+- offline/restricted builds fail unpredictably;
+- nested configure/build operations inherit incompatible toolchain policy;
+- dependency failures are misdiagnosed as libcoda source failures;
+- CI caching can hide undeclared network requirements.
+
+## CMake target policy
+
+Prefer target-scoped dependency declarations:
+
+- `target_link_libraries` with imported/owned targets;
+- `target_include_directories` with `BUILD_INTERFACE`/`INSTALL_INTERFACE` for public headers;
+- `target_compile_definitions` and `target_compile_options` rather than global flags;
+- optional backend targets created only when their dependency is available/enabled;
+- install/export lists composed from targets that actually exist.
+
+Avoid using directory-global include/link state to make a component compile accidentally.
+
+## Public versus private dependencies
+
+A dependency is `PUBLIC` only when its headers/types or compile requirements are required to consume the public target. Otherwise it should be `PRIVATE`.
+
+Examples:
+
+- a header-only library included by a public header may need to be public until that header dependency is removed;
+- PostgreSQL implementation headers used only by a `.cpp` adapter should remain private even if the adapter target itself is optional;
+- test frameworks are test-only dependencies and must not become transitive requirements of the library target.
+
+## Dependency versions
+
+Pin versions when libcoda owns the download/vendor decision. For system/package-manager dependencies, document practical minimums only when code or API usage actually requires them.
+
+Do not add a version pin solely for aesthetic consistency if the component already builds correctly against a supported distribution range.
+
+## Git submodules
+
+Project component submodules are not equivalent to third-party dependency downloads. They are explicit repository integration pins and are initialized by the checkout/integration workflow.
+
+Rules:
+
+- aggregate commits pin exact component SHAs through gitlinks;
+- component changes should be validated in their own repository before or together with aggregate integration;
+- advancing a gitlink requires aggregate CI evidence;
+- third-party libraries should not be added as new Git submodules by default; prefer package/imported-target integration unless vendoring has a documented reason.
+
+## Security expectations
+
+For fetched or vendored third-party code:
+
+- pin immutable revisions;
+- minimize execution of upstream build/bootstrap scripts;
+- review license and maintenance status;
+- keep the dependency optional if the capability is optional;
+- include dependency/version provenance in release/SBOM work when introduced.
+
+For system packages:
+
+- CI should pin the runner/distribution when package names or ABI expectations are distribution-specific;
+- avoid silently depending on headers from development/server packages that are not declared in build documentation or CI provisioning.
+
+## Test dependencies
+
+Unit-test dependencies should not be configured or fetched when tests are disabled. Migrated components should honor the shared `CODA_BUILD_TESTS` cache option when built under the aggregate repository.
+
+Service dependencies such as MySQL/PostgreSQL servers belong to explicit integration-test jobs or fixtures. Pure unit/fuzz paths must not require those services.
+
+## Review checklist
+
+When adding/changing a dependency:
+
+- Is it required by the public target, a private adapter, tests, or tooling?
+- Can it be represented as an imported CMake target?
+- Does a normal build gain a new network operation?
+- Is the version/provenance decision explicit?
+- Can the dependency be disabled with the feature that requires it?
+- Does CI provision it deterministically?
+- Does it cross a security/licensing boundary that needs documentation?


### PR DESCRIPTION
## Summary

Implements the architecture-documentation foundation for #3:

- documents libcoda's aggregate/multi-repository system context and modernization drivers;
- defines practical layered dependency rules for public API, pure/domain logic, capability ports, and adapters;
- applies SOLID as coupling guidance rather than an inheritance mandate;
- defines error categories, lifecycle/ownership expectations, exception rules, and diagnostic/redaction policy;
- defines deterministic dependency/build-time network policy and target-scoped CMake guidance;
- records ADR 0001 to retain component repositories/submodules during the current modernization phase, with explicit revisit criteria;
- links the architecture documents from the root README.

## Design intent

The documents distinguish target architecture from current legacy state. They explicitly avoid requiring broad interface hierarchies or an immediate monorepo migration.

The submodule decision is a sequencing decision: component boundaries, packaging, tests, and security contracts should stabilize before repository topology is reconsidered.

The architecture diagram explicitly represents compile-time/source dependency direction rather than runtime control flow.

## Validation

GitHub Actions run `31797070247` passed on exact head `17c2d916dfcc673ecc37f6519f7679e8674b0d9e`:

- recursive submodule checkout;
- dependency provisioning;
- release configuration;
- complete aggregate build.

The PR is documentation-only and based directly on the merged CMake foundation `3701d7c53313e68d34e198f9ca2a7fd166eae92b`.

Refs #3
Refs #4
Refs #5
Refs #7
Refs #8
Refs #9
