### PR TITLE
Make core aggregate targets own C++17 requirements

### DIFF
--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(LOG_LIBRARY coda_log)
 
 add_library(${LOG_LIBRARY} log.cpp)
+target_compile_features(${LOG_LIBRARY} PUBLIC cxx_std_17)
 
 string(REPLACE "_" "/" INSTALL_DIRECTORY ${LOG_LIBRARY})
 

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(MATH_LIBRARY coda_math)
 
 add_library(${MATH_LIBRARY} bigint.cpp util.h)
+target_compile_features(${MATH_LIBRARY} PUBLIC cxx_std_17)
 
 string(REPLACE "_" "/" INSTALL_DIRECTORY ${MATH_LIBRARY})
 

--- a/src/string/CMakeLists.txt
+++ b/src/string/CMakeLists.txt
@@ -4,13 +4,14 @@ set(STRING_LIBRARY coda_string)
 
 pkg_search_module(UUID uuid)
 
-if (UUID_FOUND)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUUID_FOUND")
-endif()
-
 set(${STRING_LIBRARY}_HEADERS argument.h buffer.h util.h )
 
 add_library(${STRING_LIBRARY} ${${STRING_LIBRARY}_HEADERS} argument.cpp buffer.cpp util.cpp)
+target_compile_features(${STRING_LIBRARY} PUBLIC cxx_std_17)
+
+if (UUID_FOUND)
+  target_compile_definitions(${STRING_LIBRARY} PRIVATE UUID_FOUND)
+endif()
 
 target_link_libraries(${STRING_LIBRARY} ${UUID_LIBRARIES})
 

--- a/src/terminal/CMakeLists.txt
+++ b/src/terminal/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TERM_LIBRARY coda_term)
 set(${TERM_LIBRARY}_HEADERS output.h cursor.h progress.h color.h base_terminal.h)
 
 add_library(${TERM_LIBRARY} ${${TERM_LIBRARY}_HEADERS} vt100.cpp color.cpp output.cpp cursor.cpp progress.cpp)
+target_compile_features(${TERM_LIBRARY} PUBLIC cxx_std_17)
 
 string(REPLACE "_" "/" INSTALL_DIRECTORY ${TERM_LIBRARY})
 


### PR DESCRIPTION
## Summary

Continues issue #2 after the root CMake foundation merge by moving aggregate-owned libraries away from ambient compiler state:

- `coda_log`, `coda_math`, `coda_string`, and `coda_term` now declare `PUBLIC cxx_std_17` on their targets;
- `UUID_FOUND` is now a private compile definition of `coda_string` instead of a global `CMAKE_CXX_FLAGS` mutation;
- header-only `thread` and `utility` directories remain unchanged because they do not define compiled targets.

## Migration boundary

The root-level `CMAKE_CXX_STANDARD=17` remains temporarily because `libcoda-dice`, `libcoda-db`, and `libcoda-net` still contain compiled targets that inherit the aggregate language mode. Those components will be migrated in subsequent slices before the global setting is removed.

No runtime or public API behavior is intended to change.

## Validation

The existing aggregate release CI recursively checks all submodules and builds the complete release graph. This PR should remain draft until that gate is green.

Refs #2
