### PR TITLE
Add security threat models and hardening baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Modernization follows explicit layered-dependency, error-handling, and dependenc
 
 The architecture documents describe target constraints for modernization; they do not imply every legacy component already conforms.
 
+Security
+========
+
+Security modernization is driven by explicit trust boundaries and component threat models:
+
+- [Project threat model and release-hardening checklist](docs/security/threat-model.md)
+- [`libcoda-net` threat model](docs/security/libcoda-net.md)
+- [`libcoda-db` threat model](docs/security/libcoda-db.md)
+- [`libcoda-format` threat model](docs/security/libcoda-format.md)
+
+The threat models record current findings as remediation inputs; documenting a legacy behavior does not make it an accepted security default.
+
 Submodules
 ==========
 

--- a/docs/security/libcoda-db.md
+++ b/docs/security/libcoda-db.md
@@ -1,0 +1,133 @@
+# libcoda-db threat model
+
+## Scope
+
+`libcoda-db` parses connection URIs, models SQL values and queries, maps bind parameters, and adapts sessions/statements/results/transactions to SQLite, MySQL/MariaDB, and PostgreSQL.
+
+Database URIs and application values may be sensitive or attacker-controlled. External databases are separate trust domains even when they are operated by the same application owner.
+
+## Security invariants
+
+1. Data values are bound separately from SQL structure wherever the backend supports binding.
+2. Raw SQL fragments/identifiers are never described as protected by parameter binding.
+3. Credentials are not exposed through routine string conversion, diagnostics, or logs.
+4. URI/query parsing is deterministic and bounded for malformed inputs.
+5. Backend-specific handles/OIDs/errors remain inside adapter boundaries unless deliberately part of a public contract.
+6. Transactions/sessions/statements reject invalid lifecycle states rather than dereferencing invalid native state.
+7. Unit/fuzz tests for query/value logic do not require a live external DB service.
+
+## Trust boundaries
+
+```text
+configuration / DB URI
+  -> URI parser + credential representation
+  -> query/value/bind model
+  -> backend adapter
+  -> external SQLite file / MySQL / PostgreSQL service
+```
+
+A string crossing from application data into SQL structure is a separate trust decision from a string bound as a value.
+
+## Current findings
+
+### DB-SEC-001 — URI string conversion retains credentials
+
+`uri_type::parse()` stores the complete original URI in `value`, while `operator std::string()` returns that value. If the input contains `user:password@host`, ordinary stringification reproduces the password.
+
+Impact: credentials can leak through logs, exception messages, debug output, telemetry, or caller diagnostics.
+
+Required direction:
+
+- make redacted display/stringification the default;
+- preserve secret-bearing raw input only when necessary and with explicit access semantics;
+- redact password/userinfo and security-sensitive query parameters;
+- add regression tests proving password material is absent from display/error representations.
+
+### DB-SEC-002 — SQL injection boundary is not documented at API level
+
+The codebase contains query generation and bind mapping, but callers need a clear contract identifying which APIs accept structural SQL versus bound data.
+
+Required direction:
+
+- document bind guarantees for statement/query APIs;
+- identify any raw SQL fragment, table, column, order-by, or expression APIs that remain structural;
+- unit/fuzz test generated SQL and bind mapping independently from live DB services;
+- avoid concatenating untrusted values into structural SQL paths.
+
+### DB-SEC-003 — PostgreSQL adapter consumes server/internal type headers
+
+The current PostgreSQL binding maps OID constants through `catalog/pg_type.h`, requiring server development headers in addition to `libpq`.
+
+Security/maintenance impact: this expands the build dependency surface and couples the client adapter to PostgreSQL server header layout/versioning.
+
+Required direction:
+
+- evaluate replacing server-header constants with a stable adapter-local mapping or supported client-facing API;
+- if retained, keep the dependency private to the PostgreSQL adapter and explicitly provision/version it.
+
+### DB-SEC-004 — credential/error redaction is not systematic
+
+Backend errors can contain connection/configuration context. No project-wide DB redaction helper/contract currently guarantees sensitive URI material is removed.
+
+Required direction:
+
+- centralize redacted URI/display behavior;
+- ensure exceptions and test diagnostics use redacted forms;
+- test representative MySQL/PostgreSQL URI failures with credentials present.
+
+## SQL structure versus values
+
+Parameter binding protects **values**, not arbitrary SQL grammar.
+
+Treat these as structural unless the API converts them through a trusted enumeration/model:
+
+- table/column identifiers;
+- sort direction;
+- operators;
+- raw WHERE/JOIN fragments;
+- function names;
+- LIMIT/OFFSET syntax on backends where not bound;
+- schema/object names.
+
+If user-controlled structural selection is required, map external strings to trusted internal identifiers rather than interpolating arbitrary input.
+
+## Lifecycle and resource risks
+
+Review session/statement/transaction/result ownership for:
+
+- null/invalid native handles after failed construction;
+- use after session/transaction completion;
+- double finalization/rollback/commit;
+- statement/result lifetime exceeding required backend owner lifetime;
+- move/copy semantics for native-handle-owning objects;
+- cleanup on backend exceptions.
+
+SQLite should be the first deterministic contract backend because it avoids service/network uncertainty while exercising real adapter lifecycle behavior.
+
+## URI parser inputs
+
+Test/fuzz at least:
+
+- missing scheme/host/path;
+- user without password;
+- password containing delimiters/escaped characters;
+- IPv6 host forms;
+- empty/malformed ports;
+- very long user/host/query components;
+- duplicate or unusual query keys;
+- percent-encoding rules if/when supported;
+- credential redaction regardless of parse success/failure.
+
+## Service integration boundary
+
+MySQL/PostgreSQL live service tests should be explicit integration jobs/fixtures and should use ephemeral credentials/databases. They should not be required for pure query/value/parser tests or fuzzing.
+
+CI logs must not echo service credentials or full connection URIs containing secrets.
+
+## Verification priorities
+
+1. Make DB URI display/error output redacted by default and add tests.
+2. Document and test SQL structure/bind boundaries.
+3. Add deterministic SQLite lifecycle/contract tests.
+4. Add SQL generation/bind/URI fuzz targets without external services.
+5. Review PostgreSQL server-header dependency and native-handle ownership under #8.

--- a/docs/security/libcoda-format.md
+++ b/docs/security/libcoda-format.md
@@ -1,0 +1,107 @@
+# libcoda-format threat model
+
+## Scope
+
+`libcoda-format` parses format strings, stores specifier/argument state, applies stream manipulators, renders values, supports reset/copy/move operations, and exposes a public C++ formatting API.
+
+Format strings should be treated as potentially untrusted when they originate from configuration, protocol data, templates, logs, or external inputs.
+
+## Security invariants
+
+1. Malformed format strings fail deterministically with documented exceptions rather than memory errors or undefined behavior.
+2. Numeric/index/width/precision parsing consumes complete tokens and rejects overflow or unsupported syntax.
+3. Specifier/index state cannot address outside owned containers/buffers.
+4. Copy/move/reset preserve valid iterator/state relationships.
+5. Rendering does not interpret format data as printf-style variadic control strings.
+6. Attacker-controlled inputs have bounded enough size/work characteristics for intended use; fuzz harnesses enforce explicit campaign bounds.
+7. Public headers do not leak namespace state or unnecessary implementation dependencies into consumers.
+
+## Trust boundary
+
+```text
+format string + typed arguments
+  -> parser/specifier model
+  -> argument binding/state
+  -> renderer/stream manipulation
+  -> resulting string/stream
+```
+
+The parser boundary should remain independently testable/fuzzable without filesystem, network, DB, clock, or random dependencies.
+
+## Current posture
+
+Recent modernization work has already improved several security properties:
+
+- public-header `using namespace std` pollution was removed;
+- canonical grammar and legacy compatibility syntax are documented;
+- index/width/precision numeric fields are parsed strictly instead of accepting `std::stoi` prefixes;
+- malformed/repeated separators, negative index/precision, and width overflow are regression-tested;
+- AFL++ harnessing exercises parse/copy/move/bind/render/reset transitions with bounded input and argument counts;
+- CI includes sanitizer and fuzz-smoke coverage in the component repository.
+
+These controls reduce parser ambiguity but do not make fuzzing or sanitizer review complete.
+
+## Primary abuse cases
+
+### Parser memory/iterator corruption
+
+Malformed braces, specifier ordering, reset operations, and copy/move state can stress iterator relationships.
+
+Mitigations:
+
+- unit tests for malformed/truncated/escaped inputs;
+- ASAN/UBSAN execution of tests and fuzz corpus;
+- fuzz copy/move/reset cycles, not only constructor parsing;
+- avoid storing iterators across container mutations unless the lifecycle invariant is explicit.
+
+### Integer/resource abuse
+
+Indexes, width, precision, format-string length, and specifier count are attacker-influenced.
+
+Mitigations:
+
+- strict decimal token parsing and overflow rejection;
+- document current width range where storage is intentionally narrow;
+- bound fuzz input and repeated argument operations;
+- review whether production parsing needs an explicit maximum input/specifier count or whether caller-level bounding is sufficient.
+
+### Unexpected argument rendering side effects
+
+User-defined argument types can execute arbitrary `operator<<` code. This is a normal C++ extensibility property, not a parser sandbox.
+
+Security contract:
+
+- libcoda-format guarantees its own parsing/state safety;
+- it does not isolate or sandbox arbitrary caller-provided streaming operators;
+- exceptions or side effects from user-defined `operator<<` remain caller/type behavior.
+
+### Output/log injection
+
+A memory-safe formatter can still render attacker-controlled newlines/control characters into logs or terminal output.
+
+Mitigations belong at the output sink/context boundary:
+
+- escape/sanitize control characters for structured logs or terminal contexts when required;
+- do not claim the formatter itself provides HTML/shell/SQL/log escaping.
+
+## Fuzzing contract
+
+The deterministic format harness should:
+
+- accept raw stdin bytes/strings;
+- bound total input size;
+- exercise constructor parsing, copy/move, argument binding, rendering, and reset;
+- classify documented `std::invalid_argument` parse failures as expected;
+- surface crashes, sanitizer failures, unexpected exceptions, hangs, and invariant violations;
+- maintain a small grammar-focused seed corpus and dictionary;
+- preserve crash reproducers as regression tests/corpus entries after triage.
+
+Long-running fuzz campaigns should be separate from normal PR latency, while bounded smoke runs remain suitable for CI.
+
+## Verification priorities
+
+1. Continue ASAN/UBSAN + AFL++ smoke on every relevant component change.
+2. Add regression tests for every parser/fuzz crash before fixing it.
+3. Review iterator/state invariants around reset/copy/move under sanitizers.
+4. Evaluate resource limits based on observed fuzz/performance behavior rather than arbitrary global caps.
+5. Keep output-context escaping explicitly out of the formatter contract unless a dedicated encoding API is added.

--- a/docs/security/libcoda-net.md
+++ b/docs/security/libcoda-net.md
@@ -1,0 +1,125 @@
+# libcoda-net threat model
+
+## Scope
+
+`libcoda-net` handles hostnames, URIs, socket lifecycle, network reads/writes, optional TLS, HTTP/curl integration, telnet/protocol behavior, and sync/async orchestration. Network peers and host/URI inputs must be treated as untrusted.
+
+## Security invariants
+
+1. A secure client connection authenticates the intended peer, not merely negotiates encryption.
+2. Socket/TLS native handles have unambiguous ownership; resource-owning types are not shallow-copyable.
+3. Buffer sizes and native API integer conversions are validated before narrowing.
+4. Public address/URI APIs return value-oriented data without shared mutable buffers.
+5. Malformed network/protocol input produces bounded errors rather than undefined behavior.
+6. Closing/shutdown is deterministic and does not double-release a resource.
+7. DNS/URI parsing does not silently change the trust decision about the requested host.
+
+## Trust boundaries
+
+```text
+caller hostname / URI
+  -> URI + DNS resolution
+  -> socket transport
+  -> TLS context / peer verification
+  -> remote peer bytes
+  -> protocol parser / client behavior
+```
+
+The hostname used for DNS resolution must remain available to TLS verification. Resolving an address is not equivalent to authenticating the host.
+
+## Current findings
+
+### NET-SEC-001 — TLS peer verification is not explicit
+
+Current OpenSSL code creates a client context and calls `SSL_connect`, but does not visibly configure trusted certificate verification or expected-hostname verification.
+
+Impact: an active attacker may be able to impersonate a TLS endpoint even though the connection is encrypted.
+
+Required direction:
+
+- use supported client TLS APIs;
+- configure certificate-chain verification;
+- bind verification to the requested hostname/IP;
+- make verification failure observable;
+- test trusted, untrusted, expired, and hostname-mismatch cases where feasible.
+
+### NET-SEC-002 — `openssl_layer` is shallow-copyable
+
+`openssl_layer` owns `SSL*` and `SSL_CTX*` but currently declares copy construction/assignment, while the implementation copies those pointers.
+
+Impact: copies can release the same native resources more than once or retain dangling handles.
+
+Required direction:
+
+- delete copy construction/assignment unless a real deep/share ownership model is implemented;
+- keep move construction/assignment explicit and no-throw where possible;
+- ensure move assignment releases any resource already owned by the destination before taking ownership.
+
+### NET-SEC-003 — raw-pointer exception ownership
+
+Socket extraction contains `throw new socket_exception(...)`.
+
+Impact: callers catching normal exceptions do not catch the pointer; ownership/leak/error behavior becomes inconsistent.
+
+Required direction: throw the exception object by value and add a regression test.
+
+### NET-SEC-004 — address string API uses shared/static storage
+
+IPv4 uses `inet_ntoa` storage and IPv6 uses a function-static buffer.
+
+Impact: returned pointers are not value-safe or reliably thread-safe and can be overwritten by later calls.
+
+Required direction: return `std::string` (or another owning value type) and use `inet_ntop` into local storage.
+
+### NET-SEC-005 — transport/TLS size and error translation
+
+`secure_layer` exposes `size_t` lengths but OpenSSL read/write APIs have version-dependent integer-size contracts and error reporting through `SSL_get_error`.
+
+Required direction:
+
+- validate/narrow lengths safely;
+- translate TLS errors consistently;
+- distinguish orderly shutdown, retryable WANT_READ/WANT_WRITE, and fatal failures where non-blocking behavior requires it.
+
+## Socket lifecycle review areas
+
+- move assignment should close/release the destination's existing socket/TLS state before taking ownership;
+- `listen()` should not attach a client TLS handshake to a listening socket; server TLS should occur on accepted connections with an explicit server context;
+- failed `setsockopt` paths must close temporary sockets before continuing;
+- accepted socket validity should use the platform `INVALID` contract rather than assuming descriptors `<= 0` are invalid;
+- `AI_PASSIVE` should be reviewed on outbound client resolution;
+- thread-safety expectations for shared socket/secure-layer instances must be documented.
+
+## Protocol and parser boundaries
+
+URI/HTTP/telnet parsers should be separable from live socket I/O. Fuzz targets should prefer pure byte/string parsing or fake transports before live network fuzzing.
+
+Test/fuzz inputs should include:
+
+- empty/truncated fields;
+- oversized lengths/counts;
+- invalid UTF-8/opaque bytes where accepted as raw protocol data;
+- duplicate/conflicting URI components;
+- unusual IPv4/IPv6 literals;
+- protocol negotiation/state transitions in unexpected order.
+
+## TLS configuration policy target
+
+The secure default should eventually be:
+
+- modern client method negotiated by OpenSSL;
+- certificate verification enabled;
+- trusted system roots or explicitly supplied trust store;
+- hostname verification using the original caller hostname;
+- SNI set when appropriate;
+- insecure/no-verify mode only if explicitly requested and clearly named/documented.
+
+No compatibility mode should silently weaken verification.
+
+## Verification priorities
+
+1. Fix copy ownership + raw-pointer exception with unit/sanitizer coverage.
+2. Make IP/address return values owning and thread-safe.
+3. Introduce an explicit TLS client verification contract and tests.
+4. Separate transport/TLS/protocol parsing boundaries under #9.
+5. Add URI/protocol/fake-transport fuzz targets under #6/#9.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,188 @@
+# libcoda security threat model
+
+## Status
+
+Active modernization baseline. Component documents refine this model for format, database, and networking code.
+
+## Scope
+
+This threat model covers the aggregate libcoda toolkit and the security boundaries created when consumers pass data into format parsing, database/query APIs, URI handling, socket/protocol code, TLS, and third-party adapters.
+
+It does not assume all legacy code already satisfies the mitigations below. Findings marked as current debt are inputs to #4, #6, #8, and #9.
+
+## Security goals
+
+1. Untrusted input must not cause memory corruption, undefined behavior, use-after-free, double-free, or process-wide compromise.
+2. Malformed input should fail through documented errors, not crashes or raw-pointer exception ownership.
+3. Database credentials and authentication material must not be exposed by normal string conversion, diagnostics, or logs.
+4. SQL construction must preserve a clear boundary between SQL structure and bound data values.
+5. Secure network connections must authenticate the intended peer; encryption without certificate/hostname verification is not sufficient.
+6. Resource use from attacker-controlled inputs should be bounded enough to resist trivial memory/CPU exhaustion.
+7. Normal builds should be deterministic and should not silently execute unpinned network dependency downloads.
+
+## Assets
+
+- process memory integrity and availability;
+- application data sent through libcoda APIs;
+- database credentials and connection URIs;
+- SQL statement/data integrity;
+- TLS trust decisions and network confidentiality/integrity;
+- socket/file descriptor and native-library handle ownership;
+- build dependency provenance and CI integrity;
+- consumer expectations encoded in public APIs and error contracts.
+
+## Threat actors and inputs
+
+Relevant threats can originate from:
+
+- a remote network peer controlling bytes returned to a socket/protocol parser;
+- an attacker controlling a hostname, URI, request/response field, or format string;
+- partially trusted configuration containing database URIs/credentials;
+- application data accidentally passed through unsafe SQL/string construction paths;
+- a malicious or compromised external database/network service;
+- a compromised or drifting third-party dependency source;
+- ordinary callers exercising undocumented lifecycle states that expose unsafe ownership bugs.
+
+The model does not require a malicious caller for every defect. Memory ownership and error-handling defects are security-relevant because benign failures can become exploitable when inputs later become attacker-controlled.
+
+## Trust boundaries
+
+```mermaid
+flowchart LR
+    Input[Untrusted / partially trusted input]
+    Format[Format parser + renderer]
+    DBModel[DB URI / query / value model]
+    DBAdapter[DB adapters]
+    Database[(External databases)]
+    NetParse[URI / protocol parsing]
+    Transport[Socket + TLS adapters]
+    Network[(Remote network)]
+    Build[Build / dependency resolution]
+    ThirdParty[Third-party packages or fetched source]
+
+    Input --> Format
+    Input --> DBModel
+    DBModel --> DBAdapter
+    DBAdapter --> Database
+    Input --> NetParse
+    NetParse --> Transport
+    Transport <--> Network
+    Build --> ThirdParty
+```
+
+Each arrow crossing into an adapter or parser is a validation/ownership boundary. Data that is safe as a value is not automatically safe as SQL structure, a hostname trust decision, a buffer length, or a log message.
+
+## Primary abuse cases
+
+### Memory and ownership corruption
+
+Risk sources include native handles, raw pointers, copied resource owners, buffer lengths, and lifecycle state.
+
+Mitigations:
+
+- RAII and single-owner semantics for native resources;
+- delete copy operations for non-shareable OpenSSL/socket/native-handle owners unless deep-copy semantics are proven;
+- sanitizer coverage for resource-owning code;
+- fuzz parser/state transitions with bounded inputs;
+- validate sizes before narrowing from `size_t` to C APIs using smaller integer types.
+
+### Credential disclosure
+
+Database URIs can contain usernames/passwords. A parsed URI representation must not make the raw credential-bearing string the default log/display representation.
+
+Mitigations:
+
+- separate raw/secret-bearing input from redacted display output;
+- redact passwords and authentication query parameters in exceptions/logs;
+- test stringification/error paths with credentials present;
+- avoid copying credentials into diagnostics unless explicitly requested by a trusted caller.
+
+### SQL injection / query confusion
+
+Mitigations:
+
+- use bind parameters for data values;
+- keep SQL structure generation separate from user data values;
+- document where raw SQL fragments are intentionally accepted;
+- unit/fuzz test query generation and bind mapping without a live service;
+- do not claim binding protects identifiers or SQL syntax that is concatenated structurally.
+
+### TLS peer impersonation
+
+A TLS handshake that does not verify certificate trust and the requested hostname is vulnerable to active interception.
+
+Mitigations:
+
+- use a client TLS method appropriate to supported OpenSSL versions;
+- enable certificate-chain verification with trusted roots;
+- verify the expected hostname/IP against the certificate;
+- expose verification failure as a stable error;
+- test failure for untrusted/mismatched certificates;
+- document any explicitly insecure mode and never make it the default.
+
+### Parser/resource exhaustion
+
+Mitigations:
+
+- bound fuzz harness input and repeated operations;
+- avoid unbounded recursion or attacker-driven allocation where practical;
+- validate indexes, widths, lengths, counts, and integer conversions;
+- treat malformed input as expected parse failure rather than retry loops or partial unsafe state.
+
+### Build/dependency compromise
+
+Mitigations:
+
+- prefer installed/imported dependency targets;
+- disable build-time network fetching by default;
+- pin any explicit fallback download;
+- use read-only CI permissions and non-persisted checkout credentials;
+- pin runner environments where dependency package contracts are version-specific;
+- add SBOM/provenance work when packaging/release automation matures.
+
+## Current high-priority findings
+
+The current modernization review identified these concrete risks:
+
+1. **Network TLS verification:** the OpenSSL layer creates a client context and performs `SSL_connect`, but current code does not establish visible certificate-chain or hostname verification policy.
+2. **OpenSSL ownership:** `openssl_layer` exposes copy construction/assignment while owning `SSL*` and `SSL_CTX*`; shallow copying native owners can lead to double-free/use-after-free.
+3. **Raw-pointer exception:** socket extraction still contains `throw new socket_exception(...)`.
+4. **Static/shared address buffers:** socket IP rendering uses APIs/static storage that are not safe as a value-oriented/thread-safe public result.
+5. **DB credential representation:** `uri_type` stores the original URI and its string conversion returns it, including any parsed password.
+
+These are remediation inputs, not accepted behavior.
+
+## Security verification strategy
+
+Security assurance should be layered:
+
+- unit tests for validation/error/redaction contracts;
+- deterministic integration tests with SQLite/fake transports;
+- ASAN/UBSAN for memory/undefined behavior;
+- TSAN where shared network state becomes meaningful;
+- AFL++/other fuzzing for parsers, bind/query generation, protocol boundaries, and state transitions;
+- static analysis (`clang-tidy`, CodeQL and/or equivalent) for ownership/API misuse;
+- explicit service-integration jobs for MySQL/PostgreSQL/live networking rather than coupling them to unit tests.
+
+## Release hardening checklist
+
+Before treating a release as hardened:
+
+- [ ] normal CI build/test path is green on supported toolchains;
+- [ ] sanitizer jobs are green for applicable components;
+- [ ] static analysis has no untriaged high-confidence security findings;
+- [ ] fuzz smoke targets build and execute checked-in corpora;
+- [ ] no normal build requires implicit third-party network fetching;
+- [ ] credentials are redacted from routine errors/logs;
+- [ ] TLS verification defaults are documented and secure;
+- [ ] resource-owning types have reviewed copy/move/destruction semantics;
+- [ ] optional DB/network backends are isolated behind explicit targets/options;
+- [ ] known security exceptions/deviations are documented with bounded follow-up issues.
+
+## Related architecture
+
+This model is constrained by:
+
+- [`../architecture/0002-layered-architecture.md`](../architecture/0002-layered-architecture.md)
+- [`../architecture/0003-error-handling.md`](../architecture/0003-error-handling.md)
+- [`../architecture/0004-dependency-policy.md`](../architecture/0004-dependency-policy.md)


### PR DESCRIPTION
## Summary

Implements the documentation/threat-model foundation for #4:

- adds a project-level security threat model with assets, actors, trust boundaries, abuse cases, verification strategy, and release-hardening checklist;
- adds component threat models for `libcoda-net`, `libcoda-db`, and `libcoda-format`;
- records concrete current findings rather than generic security categories;
- links the security documentation from the root README.

## Current findings captured

The threat models explicitly track:

- net TLS connections with no visible certificate/hostname verification policy;
- shallow-copyable OpenSSL native-handle ownership;
- a raw-pointer `socket_exception` throw;
- shared/static socket address buffers and lifecycle concerns;
- DB URI string conversion retaining credential-bearing raw input;
- SQL structure versus bound-value trust boundaries;
- PostgreSQL server-header dependency coupling;
- format parser/resource boundaries and the sanitizer/AFL++ controls already landed.

## Architecture alignment

The threat model is constrained by the merged layered architecture, error-handling policy, and deterministic dependency policy from #3. Findings are remediation inputs, not accepted defaults.

## Validation

GitHub Actions run `31797482049` passed on exact documentation head `4415c5502ae58cc5573918111778f62565272adf`. The change is documentation-only; the subsequent development-base movement is an independent dice gitlink update with no overlapping files.

Refs #4
Refs #5
Refs #6
Refs #8
Refs #9
