### PR TITLE
Remove aggregate global C++17 defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.21)
 
 project(coda VERSION 0.5.1 LANGUAGES CXX)
 
-# Transitional project-wide language defaults. These remain global until each
-# component target owns its compile features as part of issue #2.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 option(CODA_BUILD_TESTS "Build libcoda tests." ON)
 option(CODA_ENABLE_COVERAGE "Enable code coverage testing." OFF)
 option(CODA_ENABLE_MEMCHECK "Enable Valgrind memory checking." OFF)

--- a/docs/build.md
+++ b/docs/build.md
@@ -47,10 +47,12 @@ Current project-level options are:
 
 ## Modernization boundary
 
-The root build is being modernized incrementally. This first slice deliberately keeps the project-wide C++17 setting because several component libraries are Git submodules and still inherit language configuration from the aggregate build. As those component targets migrate, they should declare their own `target_compile_features(... cxx_std_17)` and target-local compile definitions/options.
+The aggregate no longer sets a project-wide C++ standard. Each compiled library target in the current aggregate graph declares its own `target_compile_features(... cxx_std_17)` requirement, including the migrated format, dice, DB, and network submodules. This keeps language requirements attached to the targets that need them and prevents ambient compiler state from masking incomplete component configuration.
 
-The root `LIBRARY_VERSION` definition is now target-local to `coda` rather than injected through `CMAKE_CXX_FLAGS`.
+The root `LIBRARY_VERSION` definition is target-local to `coda` rather than injected through `CMAKE_CXX_FLAGS`.
 
-`CODA_BUILD_TESTS` now governs the aggregate root tests and the migrated `format`, `db`, and `net` component test trees through the shared cache option. Other legacy components may still own independent test setup until they are migrated. Issue #5 tracks completing that convergence and removing remaining build-time test dependency fetching.
+`CODA_BUILD_TESTS` now governs the aggregate root tests and the migrated `format`, `dice`, `db`, and `net` component test trees through the shared cache option. Issue #5 tracks completing the remaining test-system convergence, including legacy Bandit setup and build-time test dependency behavior.
+
+Some analysis paths still use legacy shared CMake helpers that mutate global compiler flags, particularly coverage instrumentation. Those are intentionally separate from the language-requirement migration and remain tracked under issues #2 and #5.
 
 The release CI gate recursively initializes submodules and proves the full aggregate compile graph with shared tests disabled. Test-layer CI, sanitizers, coverage, and service-backed integration tests remain separate follow-up work under issue #5.


### PR DESCRIPTION
## Summary

Completes the language-requirement portion of issue #2 by removing the aggregate-wide `CMAKE_CXX_STANDARD` and `CMAKE_CXX_STANDARD_REQUIRED` defaults.

Every compiled target in the current aggregate graph now owns its C++17 requirement through `target_compile_features(... cxx_std_17)`, including:

- aggregate `coda`;
- in-tree log/math/string/terminal targets;
- `libcoda-format`;
- `libcoda-dice`;
- `libcoda-db` core and backend targets;
- `libcoda-net` core/protocol targets.

The build documentation is updated to make target-owned language requirements the explicit policy and to distinguish remaining legacy global analysis flags (notably coverage) from the completed language migration.

## Dependency completion

The component prerequisites are now merged into `development`: core target ownership, dice, DB, and network target contracts. This branch has been merged with the current `development` head, so the remaining PR diff should be limited to root CMake policy and its documentation.

## Validation

The aggregate release CI is the proof: if the recursive build succeeds without a project-wide C++ standard, no compiled component is relying on ambient language configuration.

The earlier proof run `31798299623` exercised the same final tree content before the history/base cleanup. A current-head run is preferred for final merge provenance.

Refs #2
